### PR TITLE
Add a note about JuliaFormatter version that contains `sciml` style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1180,6 +1180,8 @@ Additionally you may find the [Julia VS-Code plugin](https://github.com/julia-vs
 
 ### JuliaFormatter
 
+**Note: the** `sciml` **style is only available in** `JuliaFormatter v1.0` **or later**
+
 One can add `.JuliaFormatter.toml` with the content
 ```toml
 style = "sciml"


### PR DESCRIPTION
Hi everyone, I hope this finds you well, 😄  I think it'd be helpful to add this info to the style guide. I was trying to run the Format check workflow without formatting with the correct style and it was failing 🥲 But it worked when Dr. Rackauckas told me to use JuliaFormatter v1.0 or later 🥳. Thanks for you attention 😄 