### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -17,17 +17,5 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: julia-actions/cache@v3
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=docs/ docs/make.jl
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,23 @@
+name: Downgrade
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
+
+jobs:
+  downgrade:
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,9 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.1 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit" 

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,0 +1,29 @@
+name: "Tests"
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/**"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
+
+jobs:
+  test:
+    name: "Tests"
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts all CI to the SciML centralized reusable workflows (pinned `@v1`, `secrets: "inherit"` on every caller).

## Converted (inline -> central)
- **Documentation.yml**: inline Documenter build -> `documentation.yml@v1`
- **FormatCheck.yml** (Runic): inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: inline `crate-ci/typos` -> `spellcheck.yml@v1`

## Added
- **Tests.yml**: new `tests.yml@v1` caller (the package had no Tests workflow). Note: `test/runtests.jl` is currently empty, so this run is effectively a no-op until tests are added.
- **Downgrade.yml**: new `downgrade.yml@v1` caller (`julia-version: lts`, `skip: Pkg,TOML`).

## Cleanup
- `dependabot.yml`: removed the `crate-ci/typos` ignore block; dropped `/test` from the `julia` ecosystem dirs (no `Project.toml` there — test deps live in the root `[extras]`/`[targets]`).

## Checks
- Runic: ran `Runic.main(["--inplace","."])` locally — no changes (already clean).
- typos: ran `typos -w .` then `typos .` -> exit 0, no changes (already clean). 0 typos fixed.
- All changed YAML validated with `yaml.safe_load`.

## Heads-up
Check names change (e.g. the Runic job moves under the reusable workflow), so branch-protection required-status-check names will need updating after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)